### PR TITLE
[FIX]: #41 Low contrast: Browse Syllabus button blends with page 

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -95,14 +95,16 @@
   border: 2px solid transparent;
 }
 
-.btn-primary {
+.btn-primary-home {
   background: linear-gradient(45deg, #ffd700, #ffed4a);
   color: #333;
-  box-shadow: 0 4px 15px rgba(255, 215, 0, 0.3);
+  box-shadow: 0 4px 15px #f5798a5d;
 }
 
-.btn-primary:hover {
+.btn-primary-home:hover {
+  background: #f5576c;
   transform: translateY(-3px);
+  color: white;
   box-shadow: 0 8px 25px rgba(255, 215, 0, 0.4);
 }
 

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -178,7 +178,7 @@ const scrollToTop = () => {
               variants={staggerChildrenFast}
             >
               <motion.div variants={scaleIn}>
-                <Link to="/syllabus" className="btn btn-primary">
+                <Link to="/syllabus" className="btn btn-primary-home">
                   <motion.span
                     whileHover={{ scale: 1.05 }}
                     whileTap={{ scale: 0.95 }}


### PR DESCRIPTION
## Description  
The "Browse Syllabus" button previously had a background color that closely matched the page background, reducing its visibility and accessibility.  

Fixes #41 

## Changes Made  
- Updated the button background to a higher-contrast color.  
- Ensured sufficient contrast ratio for better readability and accessibility.  
- Maintained design consistency with the overall theme.  

## Result  
The "Browse Syllabus" button is now clearly visible and accessible across different screen sizes and themes.  


https://github.com/user-attachments/assets/10e3b6fb-2889-403e-9e63-136e002e0292


