### PR TITLE
feat: add scroll to top buttons to pages

### DIFF
--- a/client/src/pages/About.js
+++ b/client/src/pages/About.js
@@ -1,6 +1,7 @@
-import React from 'react';
-import { motion } from 'framer-motion';
+import React, { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import { Link } from 'react-router-dom';
+import { FaArrowUp } from "react-icons/fa";
 import './About.css';
 
 const About = () => {
@@ -30,6 +31,29 @@ const About = () => {
     visible: { opacity: 1, x: 0, transition: { duration: 0.6, ease: "easeOut" } }
   };
 
+  const [showScroll, setShowScroll] = useState(false);
+
+  useEffect(() => {
+    const checkScrollTop = () => {
+      if (!showScroll && window.scrollY > 300) {
+        setShowScroll(true);
+      } else if (showScroll && window.scrollY <= 300) {
+        setShowScroll(false);
+      }
+    };
+
+    window.addEventListener('scroll', checkScrollTop);
+    return () => {
+      window.removeEventListener('scroll', checkScrollTop);
+    };
+  }, [showScroll]);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  };
 
   return (
     <div className="about">
@@ -233,6 +257,24 @@ const About = () => {
           </motion.div>
         </div>
       </motion.section>
+
+      {/* Scroll to Top Button */}
+      <AnimatePresence>
+        {showScroll && (
+          <motion.button
+            key="scrollTop"
+            className="scroll-to-top"
+            onClick={scrollToTop}
+            initial={{ opacity: 0, scale: 0.5 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.5 }}
+            whileHover={{ scale: 1.15, rotate: 5 }}
+            whileTap={{ scale: 0.95 }}
+          >
+            <FaArrowUp />
+          </motion.button>
+        )}
+      </AnimatePresence>
     </div>
   );
 };

--- a/client/src/pages/Analytics.js
+++ b/client/src/pages/Analytics.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Bar, Pie } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
@@ -9,7 +9,8 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
-import { motion } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
+import { FaArrowUp } from "react-icons/fa";
 import './Analytics.css';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, Tooltip, Legend);
@@ -64,6 +65,33 @@ const Analytics = () => {
   // State to track selected subject
   const [selectedSubject, setSelectedSubject] = useState('all');
 
+  // State for the scroll-to-top button
+  const [showScroll, setShowScroll] = useState(false);
+
+  // Effect to handle scroll events for the button
+  useEffect(() => {
+    const checkScrollTop = () => {
+      if (!showScroll && window.scrollY > 300) {
+        setShowScroll(true);
+      } else if (showScroll && window.scrollY <= 300) {
+        setShowScroll(false);
+      }
+    };
+
+    window.addEventListener('scroll', checkScrollTop);
+    return () => {
+      window.removeEventListener('scroll', checkScrollTop);
+    };
+  }, [showScroll]);
+
+  // Function to scroll to the top
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  };
+  
   // Function to handle download
   const handleDownload = (subject) => {
     let fileUrl = '';
@@ -198,8 +226,26 @@ const Analytics = () => {
           </motion.button>
         </motion.section>
       </div>
-    </div>
-  );
+
+      {/* Scroll to Top Button */}
+      <AnimatePresence>
+        {showScroll && (
+          <motion.button
+            key="scrollTop"
+            className="scroll-to-top"
+            onClick={scrollToTop}
+            initial={{ opacity: 0, scale: 0.5 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.5 }}
+            whileHover={{ scale: 1.15, rotate: 5 }}
+            whileTap={{ scale: 0.95 }}
+          >
+            <FaArrowUp />
+          </motion.button>
+        )}
+      </AnimatePresence>
+     </div>
+   );
 };
 
 export default Analytics;

--- a/client/src/pages/Faq.js
+++ b/client/src/pages/Faq.js
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
-import { motion } from "framer-motion";
+import React, { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import "./Faq.css";
-import { FaGithub, FaLinkedin, FaDiscord} from "react-icons/fa";
+import { FaGithub, FaLinkedin, FaDiscord, FaArrowUp} from "react-icons/fa";
 import { Link } from "react-router-dom";
 import { SiX } from "react-icons/si";
 
@@ -57,6 +57,7 @@ import { SiX } from "react-icons/si";
 
 const Faq = () => {
   const [openIndex, setOpenIndex] = useState(null);
+  const [showScroll, setShowScroll] = useState(false);
 
   const faqs = [
     {
@@ -84,6 +85,30 @@ const Faq = () => {
       a: "Reach out to us via the Contact section at the bottom of the page or email support@studymateplus.com."
     }
   ];
+
+  // Effect to handle scroll events for the button
+  useEffect(() => {
+    const checkScrollTop = () => {
+      if (!showScroll && window.scrollY > 300) {
+        setShowScroll(true);
+      } else if (showScroll && window.scrollY <= 300) {
+        setShowScroll(false);
+      }
+    };
+
+    window.addEventListener('scroll', checkScrollTop);
+    return () => {
+      window.removeEventListener('scroll', checkScrollTop);
+    };
+  }, [showScroll]);
+
+  // Function to scroll to the top
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  };
 
   return (
     <div className="faq-page">
@@ -224,6 +249,24 @@ const Faq = () => {
     </motion.div>
   </div>
 </motion.footer>
+
+      {/* Scroll to Top Button */}
+      <AnimatePresence>
+        {showScroll && (
+          <motion.button
+            key="scrollTop"
+            className="scroll-to-top"
+            onClick={scrollToTop}
+            initial={{ opacity: 0, scale: 0.5 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.5 }}
+            whileHover={{ scale: 1.15, rotate: 5 }}
+            whileTap={{ scale: 0.95 }}
+          >
+            <FaArrowUp />
+          </motion.button>
+        )}
+      </AnimatePresence>
     </div>
   );
 };

--- a/client/src/pages/Feedback.js
+++ b/client/src/pages/Feedback.js
@@ -1,11 +1,13 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import "./Feedback.css";
 import { Link } from "react-router-dom";
+import { FaArrowUp } from "react-icons/fa";
 
 const Feedback = () => {
   const [selectedFilter, setSelectedFilter] = useState("all");
   const [selectedUniversity, setSelectedUniversity] = useState("all");
+  const [showScroll, setShowScroll] = useState(false);
 
   // Sample feedback data
   const feedbackData = [
@@ -158,6 +160,30 @@ const Feedback = () => {
     "Cochin University",
   ];
   const difficulties = ["all", "easy", "moderate", "hard"];
+
+  // Effect to handle scroll events for the button
+  useEffect(() => {
+    const checkScrollTop = () => {
+      if (!showScroll && window.scrollY > 300) {
+        setShowScroll(true);
+      } else if (showScroll && window.scrollY <= 300) {
+        setShowScroll(false);
+      }
+    };
+
+    window.addEventListener('scroll', checkScrollTop);
+    return () => {
+      window.removeEventListener('scroll', checkScrollTop);
+    };
+  }, [showScroll]);
+
+  // Function to scroll to the top
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  };
 
   const filteredFeedback = feedbackData.filter((feedback) => {
     const matchesDifficulty =
@@ -627,6 +653,24 @@ const Feedback = () => {
           </motion.div>
         </div>
       </motion.section>
+      
+      {/* Scroll to Top Button */}
+      <AnimatePresence>
+        {showScroll && (
+          <motion.button
+            key="scrollTop"
+            className="scroll-to-top"
+            onClick={scrollToTop}
+            initial={{ opacity: 0, scale: 0.5 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.5 }}
+            whileHover={{ scale: 1.15, rotate: 5 }}
+            whileTap={{ scale: 0.95 }}
+          >
+            <FaArrowUp />
+          </motion.button>
+        )}
+      </AnimatePresence>
     </div>
   );
 };

--- a/client/src/pages/MindMapEditor.js
+++ b/client/src/pages/MindMapEditor.js
@@ -9,8 +9,9 @@ import 'reactflow/dist/style.css';
 import './MindMapEditor.css';
 
 import { v4 as uuid } from 'uuid';
-import { motion } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
 import { Layers, Moon, Sun, Download, Upload, Save, Search, Plus, Trash2 } from 'lucide-react';
+import { FaArrowUp } from "react-icons/fa";
 import * as htmlToImage from 'html-to-image';
 
 // ---- Subject palette ----
@@ -72,6 +73,7 @@ export default function MindMapEditor() {
   const [edges, setEdges] = useState([]);
   const [selectedId, setSelectedId] = useState('root');
   const [collapsed, setCollapsed] = useState(new Set());
+  const [showScroll, setShowScroll] = useState(false);
 
   // Persist
   useEffect(() => {
@@ -93,6 +95,30 @@ export default function MindMapEditor() {
     if (toast) { toast.style.opacity = 1; setTimeout(() => (toast.style.opacity = 0), 900); }
   }, [nodes, edges, collapsed]);
   useEffect(() => { localStorage.setItem('smp_theme', dark ? 'dark' : 'light'); }, [dark]);
+
+  // Effect to handle scroll events for the button
+  useEffect(() => {
+    const checkScrollTop = () => {
+      if (!showScroll && window.scrollY > 300) {
+        setShowScroll(true);
+      } else if (showScroll && window.scrollY <= 300) {
+        setShowScroll(false);
+      }
+    };
+
+    window.addEventListener('scroll', checkScrollTop);
+    return () => {
+      window.removeEventListener('scroll', checkScrollTop);
+    };
+  }, [showScroll]);
+
+  // Function to scroll to the top
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  };
 
   // Derived: filter by collapsed + search highlighting
   const hiddenTargets = useMemo(() => computeHiddenTargets(collapsed, edges), [collapsed, edges]);
@@ -344,6 +370,24 @@ export default function MindMapEditor() {
           <div style={{ opacity: .7, fontSize: 14 }}>Select a node to edit.</div>
         )}
       </div>
-    </div>
-  );
+
+      {/* Scroll to Top Button */}
+      <AnimatePresence>
+        {showScroll && (
+          <motion.button
+            key="scrollTop"
+            className="scroll-to-top"
+            onClick={scrollToTop}
+            initial={{ opacity: 0, scale: 0.5 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.5 }}
+            whileHover={{ scale: 1.15, rotate: 5 }}
+            whileTap={{ scale: 0.95 }}
+          >
+            <FaArrowUp />
+          </motion.button>
+        )}
+      </AnimatePresence>
+   </div>
+ );
 }

--- a/client/src/pages/Notes.jsx
+++ b/client/src/pages/Notes.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { FaArrowUp } from "react-icons/fa";
 import './Notes.css';
 
 const Notes = () => {
@@ -37,6 +38,29 @@ const Notes = () => {
   const [selectedSubject, setSelectedSubject] = useState('All');
   const [sortBy, setSortBy] = useState('downloads');
   const [previewUrl, setPreviewUrl] = useState(null);
+  const [showScroll, setShowScroll] = useState(false);
+
+  useEffect(() => {
+  const checkScrollTop = () => {
+    if (!showScroll && window.scrollY > 300) {
+      setShowScroll(true);
+    } else if (showScroll && window.scrollY <= 300) {
+      setShowScroll(false);
+    }
+  };
+
+  window.addEventListener('scroll', checkScrollTop);
+  return () => {
+    window.removeEventListener('scroll', checkScrollTop);
+  };
+}, [showScroll]);
+
+const scrollToTop = () => {
+  window.scrollTo({
+    top: 0,
+    behavior: 'smooth'
+  });
+};
 
   // Prevent background scroll when modal is open
   useEffect(() => {
@@ -185,8 +209,26 @@ const Notes = () => {
           </motion.div>
         )}
       </AnimatePresence>
-    </div>
-  );
+
+      {/* Scroll to Top Button */}
+      <AnimatePresence>
+        {showScroll && (
+          <motion.button
+            key="scrollTop"
+            className="scroll-to-top"
+            onClick={scrollToTop}
+            initial={{ opacity: 0, scale: 0.5 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.5 }}
+            whileHover={{ scale: 1.15, rotate: 5 }}
+            whileTap={{ scale: 0.95 }}
+          >
+            <FaArrowUp />
+          </motion.button>
+        )}
+      </AnimatePresence>
+   </div>
+ );
 };
 
 export default Notes;

--- a/client/src/pages/PYQs.js
+++ b/client/src/pages/PYQs.js
@@ -1,5 +1,6 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { FaArrowUp } from "react-icons/fa";
 import "./PYQs.css";
 
 const PYQs = () => {
@@ -26,6 +27,7 @@ const PYQs = () => {
   const [selectedSubject, setSelectedSubject] = useState("");
 
   const universities = ["Select University", "LPU", "DU", "JNU"];
+  const [showScroll, setShowScroll] = useState(false);
   
   // Sample papers data (remains the same)
   const samplePapers = [
@@ -61,6 +63,29 @@ const PYQs = () => {
   );
 
   const areFiltersSelected = selectedUniversity && selectedDepartment && selectedSubject && selectedSemester;
+
+  useEffect(() => {
+  const checkScrollTop = () => {
+    if (!showScroll && window.scrollY > 300) {
+      setShowScroll(true);
+    } else if (showScroll && window.scrollY <= 300) {
+      setShowScroll(false);
+    }
+  };
+
+  window.addEventListener('scroll', checkScrollTop);
+  return () => {
+    window.removeEventListener('scroll', checkScrollTop);
+  };
+}, [showScroll]);
+
+// Add this function to perform the scroll action
+const scrollToTop = () => {
+  window.scrollTo({
+    top: 0,
+    behavior: 'smooth'
+  });
+};
 
   return (
     <div className="pyqs-page">
@@ -199,6 +224,24 @@ const PYQs = () => {
           </AnimatePresence>
         </div>
       </motion.section>
+
+      {/* Scroll to Top Button */}
+      <AnimatePresence>
+        {showScroll && (
+          <motion.button
+            key="scrollTop"
+            className="scroll-to-top"
+            onClick={scrollToTop}
+            initial={{ opacity: 0, scale: 0.5 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.5 }}
+            whileHover={{ scale: 1.15, rotate: 5 }}
+            whileTap={{ scale: 0.95 }}
+          >
+            <FaArrowUp />
+          </motion.button>
+        )}
+      </AnimatePresence>
     </div>
   );
 };

--- a/client/src/pages/Syllabus.js
+++ b/client/src/pages/Syllabus.js
@@ -1,5 +1,6 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { FaArrowUp } from "react-icons/fa";
 import './Syllabus.css';
 
 const Syllabus = () => {
@@ -125,6 +126,30 @@ const Syllabus = () => {
   const scaleIn = {
     hidden: { opacity: 0, scale: 0.85 },
     visible: { opacity: 1, scale: 1, transition: { duration: 0.5, ease: "easeOut" } }
+  };
+
+const [showScroll, setShowScroll] = useState(false);
+
+  useEffect(() => {
+    const checkScrollTop = () => {
+      if (!showScroll && window.scrollY > 300) {
+        setShowScroll(true);
+      } else if (showScroll && window.scrollY <= 300) {
+        setShowScroll(false);
+      }
+    };
+
+    window.addEventListener('scroll', checkScrollTop);
+    return () => {
+      window.removeEventListener('scroll', checkScrollTop);
+    };
+  }, [showScroll]);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
   };
 
   // State management
@@ -394,6 +419,24 @@ const Syllabus = () => {
           </AnimatePresence>
         </div>
       </motion.section>
+
+      {/* Scroll to Top Button */}
+            <AnimatePresence>
+              {showScroll && (
+                <motion.button
+                  key="scrollTop"
+                  className="scroll-to-top"
+                  onClick={scrollToTop}
+                  initial={{ opacity: 0, scale: 0.5 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.5 }}
+                  whileHover={{ scale: 1.15, rotate: 5 }}
+                  whileTap={{ scale: 0.95 }}
+                >
+                  <FaArrowUp />
+                </motion.button>
+              )}
+            </AnimatePresence>
     </div>
   );
 };


### PR DESCRIPTION
# Pull Request Description

## Summary
This pull request introduces a **"scroll-to-top" button** to several pages of the application.  
The button appears when a user scrolls down and provides a quick, animated way to return to the top of the page, improving overall user experience and navigation, especially on content-heavy pages.

---

## Changes Made
- Updated the following files:
  - `About.js`
  - `Syllabus.js`
  - `Notes.js`
  - `PYQs.js`
  - `Analytics.js`
  - `Faq.js`
  - `Feedback.js`
  - `MindMapEditor.jsx`

- Imported:
  - `useState`
  - `useEffect`
  - `AnimatePresence`
  - `FaArrowUp`

- Implemented:
  - `useEffect` hook to listen for scroll events and control the button's visibility.
  - `scrollToTop` function to handle smooth scrolling animation.
  - Animated `<motion.button>` component into the JSX of each page (rendered conditionally).

---

## How to Test
1. Checkout this branch locally.
2. Run the application with:

    ```bash
    npm start
    ```

3. Navigate to the following pages:
   - About  
   - Syllabus  
   - Notes  
   - PYQs  
   - Analytics  
   - Faq  
   - Feedback  
   - MindMapEditor  
4. Scroll down the page.  
   ✅ The animated "scroll-to-top" button with an upward arrow should appear.  
5. Click the button.  
   ✅ The page should smoothly scroll back to the top.

---

Closes #57 